### PR TITLE
Adding decidability of equality for dtree/vtree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - 'coqorg/coq:8.14'
           - 'coqorg/coq:8.15'
           - 'coqorg/coq:8.16'
-          - 'coqorg/coq:dev'
+    #      - 'coqorg/coq:dev'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/coq-kruskal-trees.opam
+++ b/coq-kruskal-trees.opam
@@ -22,7 +22,6 @@ install: [
 
 depends: [
   "ocaml"
-  "ocamlfind"
   "coq" {>= "8.14" & < "8.17~" }
 ]
 

--- a/coq-kruskal-trees.opam
+++ b/coq-kruskal-trees.opam
@@ -21,7 +21,9 @@ install: [
 ]
 
 depends: [
-  "coq" {dev & >= "8.14"}
+  "ocaml"
+  "ocamlfind"
+  "coq" {>= "8.14" & < "8.17~" }
 ]
 
 #url { git: "https://github.com/DmxLarchey/Kruskal-Trees.git" }

--- a/theories/tree/dtree.v
+++ b/theories/tree/dtree.v
@@ -8,7 +8,7 @@
 (**************************************************************)
 
 From Coq
- Require Import Lia.
+ Require Import Arith Lia.
 
 From KruskalTrees
   Require Import notations tactics idx vec.
@@ -194,3 +194,20 @@ Tactic Notation "dtree" "inj" hyp(H) :=
   let e := fresh
   in  apply dtree_cons_inj in H as (e & H); eq refl;
       destruct H as [ H <- ]; try clear e.
+
+Section dtree_eq_dec.
+
+  Variable (X : nat -> Type) (eqX_dec : forall n (x y : X n), { x = y } + { x <> y }).
+
+  Theorem dtree_eq_dec (r t : dtree X) : { r = t } + { r <> t }.
+  Proof.
+    revert t; induction r as [ n x v IHv ]; intros [ m y w ].
+    destruct (eq_nat_dec n m) as [ <- | C ].
+    2: now right; contradict C; dtree inj C.
+    destruct (eqX_dec x y) as [ <- | C ].
+    2: now right; contradict C; dtree inj C.
+    destruct (vec_eq_dec_ext v w) as [ <- | C ]; auto.
+    now right; contradict C; dtree inj C.
+  Qed.
+
+End dtree_eq_dec.

--- a/theories/tree/vtree.v
+++ b/theories/tree/vtree.v
@@ -56,3 +56,12 @@ Section vtree.
   End wft_rect.
 
 End vtree.
+
+Section vtree_eq_dec.
+
+  Variables (X : Type) (eqX_dec : forall x y : X, { x = y } + { x <> y }).
+
+  Theorem vtree_eq_dec (r t : vtree X) : { r = t } + { r <> t }.
+  Proof. apply dtree_eq_dec; auto. Qed.
+
+End vtree_eq_dec.

--- a/theories/vec/vec.v
+++ b/theories/vec/vec.v
@@ -409,6 +409,20 @@ End vec_notations.
 
 Import vec_notations.
 
+Theorem vec_eq_dec_ext X n (u v : vec X n) :
+       (forall i, { u⦃i⦄ = v⦃i⦄ } + { u⦃i⦄ <> v⦃i⦄ })
+    -> { u = v } + { u <> v }.
+Proof.
+  induction u as [ | x n u IH ] in v |- *.
+  + vec invert v; eauto.
+  + vec invert v as y v; intros H.
+    destruct (H 𝕆) as [ C | C ]; simpl in C; subst.
+    2: now right; contradict C; apply vec_cons_inj in C.
+    specialize (fun i => H (𝕊 i)); simpl in H.
+    apply IH in H as [ <- | C ]; auto.
+    now right; contradict C; apply vec_cons_inj in C.
+Qed.
+
 Definition lvec_map {X Y} f v := match v with ⦑n,v⦒ => ⦑n,@vec_map X Y f n v⦒ end.
 
 Section vec_reif.


### PR DESCRIPTION
Using a component-wise identity test for vectors. @jjhugues this may be of interest to you if you ever switch from `ltree` to `dtree` or `vtree`.