### PR TITLE
Additional results about Forall2

### DIFF
--- a/coq-kruskal-trees.opam
+++ b/coq-kruskal-trees.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "Coq-Kruskal-Trees"
-version: "1.2"
+version: "1.3"
 synopsis: "Coq library for manipulating rose trees (ie finitely branching) as used in proof of Kruskal's tree theorem"
 description: """
    Several implementations for roses trees are proposed with proper induction principles. 
@@ -21,7 +21,7 @@ install: [
 ]
 
 depends: [
-  "coq" {>= "8.14" & < "8.21~"}
+  "coq" {>= "8.14" & < "8.20~"}
 ]
 
 #url { git: "https://github.com/DmxLarchey/Kruskal-Trees.git" }

--- a/theories/list/list_fall.v
+++ b/theories/list/list_fall.v
@@ -61,11 +61,54 @@ Section Forall2.
     + intros []; constructor; auto.
   Qed.
 
-  Local Fact Forall2_rev_rec P l m : Forall2 P l m -> Forall2 P (rev l) (rev m).
+  Fact Forall2_nil_inv_l P m : Forall2 P [] m <-> m = [].
   Proof.
-    induction 1; simpl; auto.
-    apply Forall2_app; simpl; auto.
+    split.
+    + now inversion 1.
+    + intros ->; auto.
   Qed.
+
+  Fact Forall2_nil_inv_r P l : Forall2 P l [] <-> l = [].
+  Proof.
+    split.
+    + now inversion 1.
+    + intros ->; auto.
+  Qed.
+
+  Fact Forall2_cons_inv_l P x l m : Forall2 P (x::l) m <-> exists y m', P x y /\ Forall2 P l m' /\ m = y::m'.
+  Proof.
+    split.
+    + destruct l; inversion 1; eauto.
+    + intros (? & ? & ? & ? & ->); eauto.
+  Qed.
+
+  Fact Forall2_cons_inv_r P l y m : Forall2 P l (y::m) <-> exists x l', P x y /\ Forall2 P l' m /\ l = x::l'.
+  Proof.
+    split.
+    + destruct l; inversion 1; eauto.
+    + intros (? & ? & ? & ? & ->); eauto.
+  Qed.
+
+   (** Forall2_app_inv_{l,r} already appears in stdlib since Coq 8.13 *)
+
+  Hint Resolve Forall2_app : core.
+
+  Fact Forall2_snoc_inv_l P l x m : Forall2 P (l++[x]) m <-> exists m' y, Forall2 P l m' /\ P x y /\ m = m'++[y].
+  Proof.
+    split.
+    + intros (? & ? & ? & (? & ? & ? & ->%Forall2_nil_inv_l & ->)%Forall2_cons_inv_l & ->)%Forall2_app_inv_l; eauto.
+    + intros (? & ? & ? & ? & ->); eauto.
+  Qed.
+
+  Fact Forall2_snoc_inv_r P l m y : Forall2 P l (m++[y]) <-> exists l' x, Forall2 P l' m /\ P x y /\ l = l'++[x].
+  Proof.
+    split.
+    + intros (? & ? & ? & (? & ? & ? & ->%Forall2_nil_inv_r & ->)%Forall2_cons_inv_r & ->)%Forall2_app_inv_r; eauto.
+    + intros (? & ? & ? & ? & ->); eauto.
+  Qed.
+
+  Local Fact Forall2_rev_rec P l m : Forall2 P l m -> Forall2 P (rev l) (rev m).
+  Proof. induction 1; simpl; auto. Qed.
 
   Fact Forall2_rev P l m : Forall2 P (rev l) (rev m) <-> Forall2 P l m.
   Proof.


### PR DESCRIPTION
This extension PR adds new simple results about `List.Forall2` to be used in [`Kruskal-Finite`](https://github.com/DmxLarchey/Kruskal-Finite) and [`Kruskal-Higman`](https://github.com/DmxLarchey/Kruskal-Higman) projects:
- `Forall2_{nil,cons,snoc}_inv_{l,r}` in [`list/list_fall.v`](theories/list/list_fall.v).