### PR TITLE
Small updates for Coq-8.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           - 'coqorg/coq:8.17'
           - 'coqorg/coq:8.18'
           - 'coqorg/coq:8.19'
+          - 'coqorg/coq:8.20'
 #          - 'coqorg/coq:dev'
       fail-fast: false
     steps:

--- a/coq-kruskal-trees.opam
+++ b/coq-kruskal-trees.opam
@@ -21,7 +21,7 @@ install: [
 ]
 
 depends: [
-  "coq" {>= "8.14" & < "8.20~"}
+  "coq" {>= "8.14" & < "8.21~"}
 ]
 
 #url { git: "https://github.com/DmxLarchey/Kruskal-Trees.git" }

--- a/theories/notations.v
+++ b/theories/notations.v
@@ -40,4 +40,11 @@ Definition lt_0_Sn n : 0 < S n.                             Proof. lia. Qed.
 Definition lt_n_S n m : n < m -> S n < S m.                 Proof. lia. Qed.
 Definition lt_S_n n m : S n < S m -> n < m.                 Proof. lia. Qed.
 
+(** map_length is marked deprecated in Coq 8.20 and has been renamed length_map *)
+
+Definition length_map (A B : Type) (f : A -> B) l : ⌊map f l⌋ = ⌊l⌋.
+Proof. induction l; simpl; f_equal; auto. Qed.
+
+Definition map_length := length_map.
+
 

--- a/theories/tactics.v
+++ b/theories/tactics.v
@@ -31,8 +31,10 @@ Ltac rsplit n :=
 
 (* with a goal ..., H : A, ... |- B, replace it with ... |- A = B *)
 
+(*
 Ltac replace_with H :=
   match goal with [ G : ?h |- ?c ] => match H with G => cutrewrite (c = h); [ exact H | f_equal ] end end.
+*)
 
 Tactic Notation "eq" "goal" hyp(H) :=
   match goal with

--- a/theories/vec/idx.v
+++ b/theories/vec/idx.v
@@ -34,9 +34,11 @@ Notation 𝕊 := idx_nxt.
 Section idx_rect.
 
   (* This comes from an original idea of JF Monin
-     on Smaller inversions, submitted TYPES 2022 *)
+     on Smaller inversions (TYPES 2022) *)
 
-  Inductive idx_shape_O : idx 0 → Type := .
+  (* In Set to force not being automatically 
+     transfered from Type to Prop *)
+  Inductive idx_shape_O : idx 0 → Set := .
 
   Inductive idx_shape_S {n} : idx (S n) → Type :=
     | idx_shape_S_fst : idx_shape_S 𝕆
@@ -44,14 +46,14 @@ Section idx_rect.
 
   Let idx_invert_t n : idx n → Type :=
     match n with
-      | O   => idx_shape_O
-      | S n => idx_shape_S
+    | O   => idx_shape_O
+    | S n => idx_shape_S
     end.
 
   Definition idx_invert {n} (i : idx n) : idx_invert_t i :=
     match i with
-      | 𝕆   => idx_shape_S_fst
-      | 𝕊 i => idx_shape_S_nxt i
+    | 𝕆   => idx_shape_S_fst
+    | 𝕊 i => idx_shape_S_nxt i
     end.
 
   Definition idx_O_rect X (i : idx 0) : X :=

--- a/theories/vec/vec.v
+++ b/theories/vec/vec.v
@@ -45,22 +45,22 @@ Section vec_invert.
       Following Smaller inversions by JF Monin (TYPES 2022)
     *)
 
-  Inductive vec_shape_O : vec X 0 -> Type :=
+  Inductive vec_shape_O : vec X 0 → Set :=
     | vec_shape_O_nil : vec_shape_O ∅.
 
-  Inductive vec_shape_S {n} : vec X (S n) -> Type :=
+  Inductive vec_shape_S {n} : vec X (S n) → Type :=
     | vec_shape_S_cons x v : vec_shape_S (x##v).
 
-  Definition vec_invert_t {n} : vec X n -> Type :=
+  Definition vec_invert_t {n} : vec X n → Type :=
     match n with
-      | 0   => vec_shape_O
-      | S n => vec_shape_S
+    | 0   => vec_shape_O
+    | S n => vec_shape_S
     end.
 
   Definition vec_invert {n} v : @vec_invert_t n v :=
     match v return vec_invert_t v with
-      | ∅    => vec_shape_O_nil
-      | x##v => vec_shape_S_cons x v
+    | ∅    => vec_shape_O_nil
+    | x##v => vec_shape_S_cons x v
     end.
 
   Definition vec_head n (v : vec X (S n)) :=
@@ -70,7 +70,7 @@ Section vec_invert.
 
   Definition vec_tail n (v : vec X (S n)) :=
     match vec_invert v with
-      | vec_shape_S_cons _ w => w
+    | vec_shape_S_cons _ w => w
     end.
 
   Fact vec_head_tail n (v : vec X (S n)) : v = vec_head v##vec_tail v.
@@ -104,8 +104,8 @@ Section vec_in.
   Fact vec_in_inv x n (v : vec _ n) :
          x ∈ᵥ v
        → match v with
-           | ∅    => False
-           | y##v => x = y \/ x ∈ᵥ v
+         | ∅    => False
+         | y##v => x = y \/ x ∈ᵥ v
          end.
   Proof. induction 1; auto. Qed.
 
@@ -133,19 +133,19 @@ Section vec_prj.
   Variable (X : Type).
 
   (** A nice implementation is *critical* here when using nested defs
-      Notice that pos_O_rect is implemented with
+      Notice that idx_O_rect is implemented with
 
                    match _ : Empty_set with end
 
-      which allows vec_pos v p to be recognized as a sub-term of v *)
+      which allows vec_prj v p to be recognized as a sub-term of v *)
 
   Fixpoint vec_prj n (v : vec _ n) : idx n → X :=
     match v with
-      | ∅    => idx_O_rect _
-      | x##v => λ i,
+    | ∅    => idx_O_rect _
+    | x##v => λ i,
       match idx_S_inv i with
-        | None   => x
-        | Some j => v⦃j⦄
+      | None   => x
+      | Some j => v⦃j⦄
       end
     end
   where "v ⦃ i ⦄" := (@vec_prj _ v i).
@@ -452,9 +452,9 @@ End vec_reif.
 
 Tactic Notation "vec" "reif" hyp(H) "as" simple_intropattern(P) :=
   match type of H with
-    | ∀_ : idx _, ex _ => apply vec_reif in H as P
-    | ∀_ : idx _, sig _ => apply vec_reif_t in H as P
-    | ∀_ : idx _, sigT _ => apply vec_reif_tt in H as P
+  | ∀_ : idx _, ex _ => apply vec_reif in H as P
+  | ∀_ : idx _, sig _ => apply vec_reif_t in H as P
+  | ∀_ : idx _, sigT _ => apply vec_reif_tt in H as P
   end.
 
 Section vec_cond_reif.


### PR DESCRIPTION
- Beware that `map_length` is now deprecated in Coq 8.20 and renamed `length_map` ...
- the tactic `cutrewrite` was removed but apparently, `replace_with` is not used anymore in the code, replaced with `eq goal H` probably
- corrected typos coming from older naming scheme `pos` replaced with `idx`.